### PR TITLE
tasks and client_ids should be logical strings in the public API

### DIFF
--- a/gearman/client_handler.py
+++ b/gearman/client_handler.py
@@ -32,7 +32,7 @@ class GearmanClientCommandHandler(GearmanCommandHandler):
         cmd_type = submit_cmd_for_background_priority(current_request.background, current_request.priority)
 
         outbound_data = self.encode_data(gearman_job.data)
-        self.send_command(cmd_type, task=gearman_job.task, unique=gearman_job.unique, data=outbound_data)
+        self.send_command(cmd_type, task=gearman_job.task.encode('ascii'), unique=gearman_job.unique, data=outbound_data)
 
         # Once this command is sent, our request needs to wait for a handle
         current_request.state = JOB_PENDING

--- a/gearman/worker_handler.py
+++ b/gearman/worker_handler.py
@@ -44,7 +44,7 @@ class GearmanWorkerCommandHandler(GearmanCommandHandler):
         self._client_id = client_id
 
         if self._client_id is not None:
-            self.send_command(GEARMAN_COMMAND_SET_CLIENT_ID, client_id=self._client_id)
+            self.send_command(GEARMAN_COMMAND_SET_CLIENT_ID, client_id=self._client_id.encode('ascii'))
 
     ###############################################################
     #### Convenience methods for typical gearman jobs to call #####

--- a/gearman/worker_handler.py
+++ b/gearman/worker_handler.py
@@ -38,7 +38,7 @@ class GearmanWorkerCommandHandler(GearmanCommandHandler):
 
         self.send_command(GEARMAN_COMMAND_RESET_ABILITIES)
         for task in self._handler_abilities:
-            self.send_command(GEARMAN_COMMAND_CAN_DO, task=task)
+            self.send_command(GEARMAN_COMMAND_CAN_DO, task=task.encode('ascii'))
 
     def set_client_id(self, client_id):
         self._client_id = client_id
@@ -128,6 +128,7 @@ class GearmanWorkerCommandHandler(GearmanCommandHandler):
 
         AWAITING_JOB -> EXECUTE_JOB -> SLEEP :: Always transition once we're given a job
         """
+        task = task.decode('ascii')
         assert task in self._handler_abilities, '%s not found in %r' % (task, self._handler_abilities)
 
         # After this point, we know this connection handler is holding onto the job lock so we don't need to acquire it again

--- a/tests/client_tests.py
+++ b/tests/client_tests.py
@@ -49,6 +49,7 @@ class ClientTest(_GearmanAbstractTest):
 
     def generate_job_request(self, submitted=True, accepted=True):
         current_request = super(ClientTest, self).generate_job_request()
+        current_request.job.task = current_request.job.task.decode('ascii')
         if submitted or accepted:
             self.connection_manager.establish_request_connection(current_request)
             self.command_handler.send_job_request(current_request)
@@ -166,6 +167,8 @@ class ClientTest(_GearmanAbstractTest):
     def test_multiple_fg_job_submission(self):
         submitted_job_count = 5
         expected_job_list = [self.generate_job() for _ in range(submitted_job_count)]
+        for j in expected_job_list:
+            j.task = j.task.decode('ascii')
         def mark_jobs_created(rx_conns, wr_conns, ex_conns):
             for current_job in expected_job_list:
                 self.command_handler.recv_command(GEARMAN_COMMAND_JOB_CREATED, job_handle=current_job.handle)
@@ -190,6 +193,7 @@ class ClientTest(_GearmanAbstractTest):
 
     def test_single_bg_job_submission(self):
         expected_job = self.generate_job()
+        expected_job.task = expected_job.task.decode('ascii')
         def mark_job_created(rx_conns, wr_conns, ex_conns):
             self.command_handler.recv_command(GEARMAN_COMMAND_JOB_CREATED, job_handle=expected_job.handle)
             return rx_conns, wr_conns, ex_conns
@@ -208,6 +212,7 @@ class ClientTest(_GearmanAbstractTest):
 
     def test_single_fg_job_submission_timeout(self):
         expected_job = self.generate_job()
+        expected_job.task = expected_job.task.decode('ascii')
         def job_failed_submission(rx_conns, wr_conns, ex_conns):
             return rx_conns, wr_conns, ex_conns
 
@@ -318,6 +323,7 @@ class ClientCommandHandlerInterfaceTest(_GearmanAbstractTest):
 
     def test_send_job_request(self):
         current_request = self.generate_job_request()
+        current_request.job.task = current_request.job.task.decode('ascii')
         gearman_job = current_request.job
 
         for priority in (PRIORITY_NONE, PRIORITY_HIGH, PRIORITY_LOW):
@@ -332,7 +338,7 @@ class ClientCommandHandlerInterfaceTest(_GearmanAbstractTest):
                 self.assertEqual(queued_request, current_request)
 
                 expected_cmd_type = submit_cmd_for_background_priority(background, priority)
-                self.assert_sent_command(expected_cmd_type, task=gearman_job.task, data=gearman_job.data, unique=gearman_job.unique)
+                self.assert_sent_command(expected_cmd_type, task=gearman_job.task.encode('ascii'), data=gearman_job.data, unique=gearman_job.unique)
 
     def test_get_status_of_job(self):
         current_request = self.generate_job_request()
@@ -349,6 +355,7 @@ class ClientCommandHandlerStateMachineTest(_GearmanAbstractTest):
 
     def generate_job_request(self, submitted=True, accepted=True):
         current_request = super(ClientCommandHandlerStateMachineTest, self).generate_job_request()
+        current_request.job.task = current_request.job.task.decode('ascii')
         if submitted or accepted:
             self.command_handler.requests_awaiting_handles.append(current_request)
             current_request.state = JOB_PENDING

--- a/tests/worker_tests.py
+++ b/tests/worker_tests.py
@@ -137,11 +137,11 @@ class WorkerCommandHandlerInterfaceTest(_GearmanAbstractWorkerTest):
 
     def test_on_connect(self):
         expected_abilities = ['function_one', 'function_two', 'function_three']
-        expected_client_id = 'my_client_id'
+        expected_client_id = b'my_client_id'
 
         self.connection.connected = False
 
-        self.connection_manager.set_client_id(expected_client_id)
+        self.connection_manager.set_client_id(expected_client_id.decode('ascii'))
         self.connection_manager.unregister_task('__test_ability__')
         for task in expected_abilities:
             self.connection_manager.register_task(task, None)
@@ -166,14 +166,14 @@ class WorkerCommandHandlerInterfaceTest(_GearmanAbstractWorkerTest):
         self.assert_no_pending_commands()
 
     def test_set_client_id(self):
-        expected_client_id = 'my_client_id'
+        expected_client_id = b'my_client_id'
 
         handler_initial_state = {}
         handler_initial_state['abilities'] = []
         handler_initial_state['client_id'] = None
 
         # We were disconnected, connect and wipe pending commands
-        self.command_handler.set_client_id(expected_client_id)
+        self.command_handler.set_client_id(expected_client_id.decode('ascii'))
         self.assert_sent_client_id(expected_client_id)
         self.assert_no_pending_commands()
 

--- a/tests/worker_tests.py
+++ b/tests/worker_tests.py
@@ -136,7 +136,7 @@ class WorkerCommandHandlerInterfaceTest(_GearmanAbstractWorkerTest):
     """Test the public interface a GearmanWorker may need to call in order to update state on a GearmanWorkerCommandHandler"""
 
     def test_on_connect(self):
-        expected_abilities = ['function_one', 'function_two', 'function_three']
+        expected_abilities = [b'function_one', b'function_two', b'function_three']
         expected_client_id = b'my_client_id'
 
         self.connection.connected = False
@@ -144,7 +144,7 @@ class WorkerCommandHandlerInterfaceTest(_GearmanAbstractWorkerTest):
         self.connection_manager.set_client_id(expected_client_id.decode('ascii'))
         self.connection_manager.unregister_task('__test_ability__')
         for task in expected_abilities:
-            self.connection_manager.register_task(task, None)
+            self.connection_manager.register_task(task.decode('ascii'), None)
 
         # We were disconnected, connect and wipe pending commands
         self.connection_manager.establish_connection(self.connection)
@@ -158,10 +158,10 @@ class WorkerCommandHandlerInterfaceTest(_GearmanAbstractWorkerTest):
         self.assert_no_pending_commands()
 
     def test_set_abilities(self):
-        expected_abilities = ['function_one', 'function_two', 'function_three']
+        expected_abilities = [b'function_one', b'function_two', b'function_three']
 
         # We were disconnected, connect and wipe pending commands
-        self.command_handler.set_abilities(expected_abilities)
+        self.command_handler.set_abilities([t.decode('ascii') for t in expected_abilities])
         self.assert_sent_abilities(expected_abilities)
         self.assert_no_pending_commands()
 
@@ -214,7 +214,7 @@ class WorkerCommandHandlerStateMachineTest(_GearmanAbstractWorkerTest):
 
     def setup_connection_manager(self):
         super(WorkerCommandHandlerStateMachineTest, self).setup_connection_manager()
-        self.connection_manager.register_task(b'__test_ability__', None)
+        self.connection_manager.register_task('__test_ability__', None)
 
     def setup_command_handler(self):
         super(_GearmanAbstractWorkerTest, self).setup_command_handler()
@@ -345,7 +345,7 @@ class WorkerCommandHandlerStateMachineTest(_GearmanAbstractWorkerTest):
 
         current_job = self.connection_manager.worker_job_queues[self.command_handler].popleft()
         self.assertEqual(current_job.handle, fake_job['job_handle'])
-        self.assertEqual(current_job.task, fake_job['task'])
+        self.assertEqual(current_job.task, fake_job['task'].decode('ascii'))
         self.assertEqual(current_job.unique, fake_job['unique'])
         self.assertEqual(current_job.data, fake_job['data'])
 


### PR DESCRIPTION
As in https://github.com/Yelp/python-gearman/issues/35 there are still encoding/decoding issues in this branch, this is an attempt to fix at least the ones that stops our client and worker working.

I put the encoding of the task string at the same level as encoding the data for the job, this seemed to make sense in my head but meant I had to butcher the unit tests somewhat, as they inspect the internal job structures after sending commands. Does this seem a reasonable approach to you?

The tests pass here on Python 3.4
